### PR TITLE
Bug/oracle character escape

### DIFF
--- a/app/Http/Controllers/OrderSubmissionController.php
+++ b/app/Http/Controllers/OrderSubmissionController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use Illuminate\Http\Request;
 use Exception;
 use App\Model\OrderSubmission;
+use Illuminate\Support\Facades\Log;
 
 class OrderSubmissionController extends Controller
 {
@@ -59,6 +60,7 @@ class OrderSubmissionController extends Controller
             // Validate if we get everything we need
             foreach (self::REQUIRED_FIELDS as $validationItem) {
                 if (!array_key_exists($validationItem, $requestObject)) {
+                    $result['status'] = 400;
                     throw new Exception("missing required field: " . $validationItem);
                 }
             }
@@ -72,9 +74,10 @@ class OrderSubmissionController extends Controller
 
         } catch (\Exception $exception) {
             $result['message'] = $exception->getMessage();
+            Log::error($exception);
         }
 
-        return response()->json($result);
+        return response()->json($result, $result['status']);
 
     }
 

--- a/app/Model/OrderSubmission.php
+++ b/app/Model/OrderSubmission.php
@@ -21,7 +21,7 @@ class OrderSubmission extends Model
 
         foreach ($request as $key => $value) {
             if (isset($defaultPayload[$key])) {
-                $defaultPayload[$key] = $value;
+                $defaultPayload[$key] = str_replace("'","''",$value);   //Change ' to '' to match Oracle syntax
             }
         }
 

--- a/app/Model/OrderSubmission.php
+++ b/app/Model/OrderSubmission.php
@@ -27,7 +27,7 @@ class OrderSubmission extends Model
 
         $sqlBindingValues = [];
         foreach ($defaultPayload as $key => $value) {
-            if (is_numeric($value)) {
+            if (is_numeric($value) && !in_array($key,['ship_to_zip','bill_to_zip','item_info_string'])) {
                 $sqlBindingValues[] = $value;
             } else {
                 $sqlBindingValues[] = "'" . $value . "'";


### PR DESCRIPTION
- Convert `'` to `''` to fix broken Oracle statements.
- Use more descriptive HTTP status codes for bad request and server error returns
- Log caught exceptions